### PR TITLE
Update resolve.mdx - spelling mistake "extention"

### DIFF
--- a/pages/api-reference/core/resolve.mdx
+++ b/pages/api-reference/core/resolve.mdx
@@ -44,11 +44,11 @@ read more about cache policy options in [Concepts](/concepts#cache-policy).
 
 ### `extensions`
 
-A query extention object, carrying extra information to your query fetcher.
+A query extension object, carrying extra information to your query fetcher.
 
 ```tsx
 await resolve(({ query }) => query.foo, {
-  extentions: {
+  extensions: {
     authToken: "Bearer ...",
   },
 });


### PR DESCRIPTION
This fixes a spelling mistake of "extention" in description and code example